### PR TITLE
Add screen and lldb to Termux setup

### DIFF
--- a/setup-termux.sh
+++ b/setup-termux.sh
@@ -14,7 +14,7 @@ fi
 pkg update -y && pkg upgrade -y
 
 # Dépendances nécessaires
-DEPS=(git curl python nodejs make clang)
+DEPS=(git curl python nodejs make clang screen lldb)
 
 # Installation des dépendances
 pkg install -y "${DEPS[@]}"


### PR DESCRIPTION
## Summary
- extend dependency list to install screen and lldb and verify they are available

## Testing
- `bash -n setup-termux.sh`
- `bash setup-termux.sh` *(fails: Ce script doit être exécuté dans Termux.)*


------
https://chatgpt.com/codex/tasks/task_e_68a0aac47f24832f8cb58b89fff0eb3b