### PR TITLE
chore: enable strict mode in Termux runner

### DIFF
--- a/bin/run-termux.sh
+++ b/bin/run-termux.sh
@@ -1,4 +1,5 @@
 #!/data/data/com.termux/files/usr/bin/env bash
+set -euo pipefail
 # Initialize Termux environment and optionally run a command.
 
 # Standard Termux paths


### PR DESCRIPTION
## Summary
- enforce strict bash options for Termux runner to halt on errors

## Testing
- `bash -n bin/run-termux.sh`
- `ls -l bin/run-termux.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a0b0b32d5c832f9b9065b973c39d12