### PR TITLE
Improve Termux scripts and add bootstrap helper

### DIFF
--- a/auto-termux.sh
+++ b/auto-termux.sh
@@ -1,0 +1,20 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+REPO_URL="https://github.com/tu-usuario/Claude_Coder_Koben_termux.git"
+REPO_DIR="$HOME/Claude_Coder_Koben_termux"
+
+pkg update -y
+pkg install -y git curl
+
+if [ ! -d "$REPO_DIR" ]; then
+  git clone "$REPO_URL" "$REPO_DIR"
+else
+  git -C "$REPO_DIR" pull
+fi
+
+cd "$REPO_DIR"
+./setup-termux.sh
+
+# Ejecuta un shell o la orden que se pase como argumento
+bin/run-termux.sh "$@"

--- a/bin/run-termux.sh
+++ b/bin/run-termux.sh
@@ -20,5 +20,5 @@ fi
 if [ "$#" -gt 0 ]; then
   exec "$@"
 else
-  exec "$SHELL"
+  exec "${SHELL:-$PREFIX/bin/bash}"
 fi

--- a/scripts/run_screen_debug.sh
+++ b/scripts/run_screen_debug.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/data/data/com.termux/files/usr/bin/env bash
 set -euo pipefail
 
 # Run LLDB inside a named screen session for remote debugging.

--- a/setup-termux.sh
+++ b/setup-termux.sh
@@ -11,14 +11,12 @@ if ! command -v pkg >/dev/null 2>&1; then
   exit 1
 fi
 
-# Vérifie la connectivité réseau avant la mise à jour
-if ! ping -c1 google.com >/dev/null 2>&1; then
+# Mise à jour et mise à niveau (échoue si le réseau est indisponible)
+if ! pkg update -y; then
   echo "Connexion Internet requise. Veuillez vérifier votre réseau." >&2
   exit 1
 fi
-
-# Mise à jour et mise à niveau
-pkg update -y && pkg upgrade -y
+pkg upgrade -y
 
 # Dépendances nécessaires et commandes associées
 declare -A PKG_CMDS=(


### PR DESCRIPTION
## Summary
- Fix shebang for Termux compatibility in debug script
- Use `pkg update` to verify network connectivity
- Provide default shell fallback in runner
- Add `auto-termux.sh` helper to clone and bootstrap the repo

## Testing
- `shellcheck auto-termux.sh scripts/run_screen_debug.sh setup-termux.sh bin/run-termux.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a0c3a147c8832f885724f316a4ac3d